### PR TITLE
Enable Dependabot for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,18 @@ updates:
     ignore:
       - dependency-name: "openshift/release"
         # don't automatically upgrade golang version here
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      ocm-dependencies:
+        patterns:
+          - "github.com/openshift-online/ocm-sdk-go"


### PR DESCRIPTION
## Summary
- Add Go module ecosystem to Dependabot configuration
- Configure weekly Go dependency updates
- Group K8s and OCM dependencies for cleaner PRs
- Works with the auto-merge workflow added in previous commit

## What's changed
- **Go modules**: Weekly scans for Go dependency updates
- **Dependency grouping**: K8s and OCM dependencies grouped together
- **Same labels**: Uses `area/dependency` and `ok-to-test` labels

## Test plan
- [ ] Dependabot will create Go module update PRs weekly
- [ ] Auto-merge workflow will enable auto-merge on these PRs
- [ ] PRs will auto-merge when checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)